### PR TITLE
enable custom analyzer and use word delimiter

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -24,9 +24,10 @@
   "default_settings": {
     "analysis": {
       "analyzer": {
-        "myanalyzer": {
+        "custom-analyzer": {
           "tokenizer": "standard",
           "filter": [
+            "word_delimiter_graph",
             "lowercase",
             "asciifolding"
           ]
@@ -52,14 +53,17 @@
           "sourceDataset": { "type": "keyword" },
           "prefLabel": {
             "properties": {
-              "default": { "type": "text" },
-              "en": { "type": "text" },
-              "nl": { "type": "text"},
-              "fr": { "type": "text"},
-              "de": { "type": "text"}
+              "default": { "type": "text", "analyzer": "custom-analyzer" },
+              "en": { "type": "text", "analyzer": "custom-analyzer" },
+              "nl": { "type": "text", "analyzer": "custom-analyzer" },
+              "fr": { "type": "text", "analyzer": "custom-analyzer" },
+              "de": { "type": "text", "analyzer": "custom-analyzer" }
             }
           },
-          "tagLabels": { "type": "keyword" }
+          "tagLabels": {
+            "type": "text",
+            "analyzer": "custom-analyzer"
+          }
         }
       }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - ./config/resources:/config
     restart: always
   search:
-    image: semtech/mu-search:feature-language-strings
+    image: semtech/mu-search:0.9.0-beta.6
     volumes:
       - ./config/search:/config
     restart: always

--- a/scripts/reset-elastic.sh
+++ b/scripts/reset-elastic.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 echo "warning this will run queries on the triplestore and delete containers, you have 5 seconds to press ctrl+c"
 sleep 5
-docker-compose rm -fs elasticsearch search
+docker compose rm -fs elasticsearch search
+rm config/elasticsearch/update-handler.store
 rm -rf data/elasticsearch
-docker-compose exec -T triplestore isql-v <<EOF
+docker compose exec -T triplestore isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };
 exec('checkpoint');
 exit;
 EOF
-docker-compose up -d --remove-orphans
+docker compose up -d --remove-orphans


### PR DESCRIPTION
see
https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-word-delimiter-graph-tokenfilter.html for some background

This PR also bumps mu-search to the latest version, note that this version has a runtime error on startup that  can be ignored:
```
vocabserver-app-search-1  | WARNING: Failed to load native protocols db
vocabserver-app-search-1  | java.lang.RuntimeException: getprotobyname_r failed
vocabserver-app-search-1  | 	at jnr.netdb.NativeProtocolsDB$LinuxNativeProtocolsDB.getProtocolByName(NativeProtocolsDB.java:180)
vocabserver-app-search-1  | 	at jnr.netdb.NativeProtocolsDB.load(NativeProtocolsDB.java:80)
```