### PR TITLE
by default limit memory usage of java services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,10 +85,14 @@ services:
       - ./config/search:/config
     restart: always
     logging: *default-logging
+    environment:
+      ES_JAVA_OPTS: "-Xms1g -Xmx4g"    
   elasticsearch:
     image: semtech/mu-search-elastic-backend:1.0.0
     volumes:
       - ./data/elasticsearch/:/usr/share/elasticsearch/data
+    environment:
+      ES_JAVA_OPTS: "-Xms1g -Xmx4g"      
     ulimits:
       nproc: 65536
       nofile:


### PR DESCRIPTION
java has a tendency to be quite greedy in memory usage, this setting limits the max usage to 4GB which should suffice for most scenarios. If the services do run out of memory, it can simply be increased in the docker-compose override on the server