### PR TITLE
fix search memory usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     restart: always
     logging: *default-logging
     environment:
-      ES_JAVA_OPTS: "-Xms1g -Xmx4g"    
+      JAVA_OPTS: "-Xms1g -Xmx4g"    
   elasticsearch:
     image: semtech/mu-search-elastic-backend:1.0.0
     volumes:


### PR DESCRIPTION
JAVA_OPTS should be passed as `JAVA_OPTS` instead of `ES_JAVA_OPTS`. this was likely incorrectly copied from the elasticsearch container that does need `ES_JAVA_OPTS`