### PR TITLE
Sparql-based VoID-analyses + upgrades

### DIFF
--- a/config/cl-authorization/config.lisp
+++ b/config/cl-authorization/config.lisp
@@ -1,0 +1,55 @@
+;;;;;;;;;;;;;;;;;;;
+;;; delta messenger
+(in-package :delta-messenger)
+
+(add-delta-logger)
+(add-delta-messenger "http://delta-notifier/")
+
+;;;;;;;;;;;;;;;;;
+;;; configuration
+(in-package :client)
+(setf *log-sparql-query-roundtrip* t)
+(setf *backend* "http://triplestore:8890/sparql")
+
+(in-package :server)
+(setf *log-incoming-requests-p* nil)
+
+;;;;;;;;;;;;;;;;;
+;;; access rights
+(in-package :acl)
+
+(defparameter *access-specifications* nil
+  "All known ACCESS specifications.")
+
+(defparameter *graphs* nil
+  "All known GRAPH-SPECIFICATION instances.")
+
+(defparameter *rights* nil
+  "All known GRANT instances connecting ACCESS-SPECIFICATION to GRAPH.")
+
+(type-cache::add-type-for-prefix "http://mu.semte.ch/sessions/" "http://mu.semte.ch/vocabularies/session/Session")
+
+(define-graph public ("http://mu.semte.ch/graphs/public")
+    ("http://mu.semte.ch/vocabularies/ext/VocabularyMeta" -> _)
+    ("http://mu.semte.ch/vocabularies/ext/DatasetType" -> _)
+    ("http://www.w3.org/ns/shacl#NodeShape" -> _)
+    ("http://www.w3.org/ns/shacl#PropertyShape" -> _)
+    ("http://mu.semte.ch/vocabularies/ext/VocabularyMeta" -> _)
+    ("http://rdfs.org/ns/void#Dataset" -> _)
+    ("http://mu.semte.ch/vocabularies/ext/VocabDownloadJob" -> _)
+    ("http://mu.semte.ch/vocabularies/ext/MetadataExtractionJob" -> _)
+    ("http://mu.semte.ch/vocabularies/ext/ContentUnificationJob" -> _)
+    ("http://mu.semte.ch/vocabularies/ext/VocabsExportJob" -> _)
+    ("http://mu.semte.ch/vocabularies/ext/VocabsImportJob" -> _)
+    ("http://vocab.deri.ie/cogs#Job" -> _)
+    ("http://redpencil.data.gift/vocabularies/tasks/Task" -> _)
+    ("http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer" -> _)
+    ("http://open-services.net/ns/core#Error" -> _)
+    ("http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject" -> _)
+)
+
+(supply-allowed-group "public")
+
+(grant (read write)
+  :to-graph (public)
+  :for-allowed-group "public")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,6 @@ services:
     logging: *default-logging
   triplestore:
     image: redpencil/virtuoso:1.2.0-rc.1
-    ports:
-      - 8890:8890
     environment:
       SPARQL_UPDATE: "true"
       ENABLE_CORS: "*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,11 +34,12 @@ services:
     restart: always
     logging: *default-logging
   database:
-    image: semtech/mu-authorization:0.6.0-beta.8
+    image: semtech/sparql-parser:0.0.14
     environment:
       MU_SPARQL_ENDPOINT: "http://triplestore:8890/sparql"
     volumes:
-      - ./config/authorization:/config
+      - ./config/cl-authorization:/config
+      - ./data/cl-authorization:/data
     networks:
       - default
       - ldes-consumers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,8 +119,9 @@ services:
       context: ./services/vocab-fetch
     image: ${REG_NS:-vocabserver_app}/vocab-fetch:${BUILD_TAG}
     volumes:
-      - ./data/vocab-fetch:/share
+      - ./data/files:/share
     environment:
+      MU_APPLICATION_FILE_STORAGE_PATH: "dataset-dumps/"
       MU_VIRTUOSO_ENDPOINT: "http://triplestore:8890/sparql"
       UPDATE_DATASET_DUMP_CRON_PATTERN: "5 * * * *" # hourly
       # FIXME: always run in dev mode to circumvent memory limitations
@@ -132,8 +133,9 @@ services:
       context: ./services/content-unification
     image: ${REG_NS:-vocabserver_app}/content-unification:${BUILD_TAG:-latest}
     volumes:
-      - ./data/vocab-fetch:/share
+      - ./data/files:/share
     environment:
+      MU_APPLICATION_FILE_STORAGE_PATH: "dataset-dumps/"
       MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
       MU_SPARQL_UPDATEPOINT:  "http://triplestore:8890/sparql"
       MU_AUTH_ENDPOINT: "http://database:8890/sparql"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,9 +123,11 @@ services:
     environment:
       MU_APPLICATION_FILE_STORAGE_PATH: "dataset-dumps/"
       MU_VIRTUOSO_ENDPOINT: "http://triplestore:8890/sparql"
-      UPDATE_DATASET_DUMP_CRON_PATTERN: "5 * * * *" # hourly
       # FIXME: always run in dev mode to circumvent memory limitations
       MODE: "development"
+      # Making dataset dumps takes a long time with the current sparql-implementation
+      # (2:45 for Marine Regions for example). Perform no more than once per 24h
+      UPDATE_DATASET_DUMP_CRON_PATTERN: "0 23 * * *"
     restart: always
     logging: *default-logging
   content-unification:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
     restart: always
     logging: *default-logging
   uuid-generation:
-    image: kanselarij/uuid-generation-service:1.0.0
+    image: redpencil/uuid-generation:0.4.0
     volumes:
       - ./config/uuid-generation/:/config
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
   webcomponent:
     image: ghcr.io/vlizbe/vocabserver-webcomponent:${BUILD_TAG:-latest}
   ldes-consumer-manager:
-    image: redpencil/ldes-consumer-manager:feature-client-upgrade
+    image: redpencil/ldes-consumer-manager:feature-new-client-use-exising-graph
     environment:
       MU_NETWORK: ldes-consumers
       MODE: "${MODE:-production}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,8 +123,6 @@ services:
     environment:
       MU_APPLICATION_FILE_STORAGE_PATH: "dataset-dumps/"
       MU_VIRTUOSO_ENDPOINT: "http://triplestore:8890/sparql"
-      # FIXME: always run in dev mode to circumvent memory limitations
-      MODE: "development"
       # Making dataset dumps takes a long time with the current sparql-implementation
       # (2:45 for Marine Regions for example). Perform no more than once per 24h
       UPDATE_DATASET_DUMP_CRON_PATTERN: "0 23 * * *"

--- a/services/content-unification/task.py
+++ b/services/content-unification/task.py
@@ -247,7 +247,8 @@ def run_tasks(task_uris, graph, runner_func, sparql_query, sparql_update):
         sparql_update(update_tasks_status(task_uris, STATUS_SUCCESS, graph))
         return generated
     except Exception as e:
-        traceback.print_exc()
+        logger.warn(f"Failed running task {task_uri}")
+        logger.warn(traceback.format_exc())
         sparql_update(update_tasks_status(task_uris, STATUS_FAILED, graph))
 
     # end_time = time.time()

--- a/services/content-unification/web.py
+++ b/services/content-unification/web.py
@@ -178,25 +178,19 @@ def run_scheduled_tasks():
             else:
                 logger.debug("No more tasks found")
                 return
-            try:
-                inputs_res =  query_sudo(get_input_contents_task(task_uri, TASKS_GRAPH))
-                inputs = binding_results(inputs_res, "content")
-                similar_tasks_res = query_sudo(find_same_scheduled_tasks(task_operation, inputs,  TASKS_GRAPH))
-                similar_tasks = binding_results(similar_tasks_res, "uri")
-                if task_operation == CONT_UN_OPERATION:
-                    logger.debug(f"Running task {task_uri}, operation {task_operation}")
-                    logger.debug(f"Updating at the same time: {' | '.join(similar_tasks)}")
-                    run_tasks(
-                        similar_tasks,
-                        TASKS_GRAPH,
-                        lambda sources: [run_vocab_unification(sources[0])],
-                        query_sudo,
-                        update_sudo,
-                    )
-
-            finally:
-                logger.warn(
-                    f"Problem while running task {task_uri}, operation {task_operation}"
+            inputs_res =  query_sudo(get_input_contents_task(task_uri, TASKS_GRAPH))
+            inputs = binding_results(inputs_res, "content")
+            similar_tasks_res = query_sudo(find_same_scheduled_tasks(task_operation, inputs,  TASKS_GRAPH))
+            similar_tasks = binding_results(similar_tasks_res, "uri")
+            if task_operation == CONT_UN_OPERATION:
+                logger.debug(f"Running task {task_uri}, operation {task_operation}")
+                logger.debug(f"Updating at the same time: {' | '.join(similar_tasks)}")
+                run_tasks(
+                    similar_tasks,
+                    TASKS_GRAPH,
+                    lambda sources: [run_vocab_unification(sources[0])],
+                    query_sudo,
+                    update_sudo,
                 )
     finally:
         running_tasks_lock.release()

--- a/services/vocab-fetch/sparql_util.py
+++ b/services/vocab-fetch/sparql_util.py
@@ -63,8 +63,10 @@ def graph_to_file(graph_name, graph):
     headers = {"Accept": mime_type}
 
     i = 0
+    logger.info(f"Starting graph {graph_name} dump to {shared_uri_to_path(file_resource_uri)}.")
     with open(shared_uri_to_path(file_resource_uri), "wb") as f:
         while True:
+            logger.debug(f"Writing triplestore graph to file. Batch {i+1}")
             query_string = dump_graph_query_template.substitute(
                 graph=sparql_escape_uri(graph_name),
                 offset=i*BATCH_SIZE,

--- a/services/vocab-fetch/sudo_query.py
+++ b/services/vocab-fetch/sudo_query.py
@@ -31,12 +31,11 @@ def update_sudo(the_query, attempt=0, max_retries=5):
     if sparqlUpdate.isSparqlUpdateRequest():
         try:
             start = time.time()
-            logger.debug(f"started query at {datetime.datetime.now()}")
             logger.debug("execute query: \n" + the_query)
 
             sparqlUpdate.query()
 
-            logger.debug(f"query took {time.time() - start} seconds")
+            logger.debug(f"Query took {round((time.time() - start) * 10**3)} ms")
         except Exception as e:
             logger.warn("Executing query failed unexpectedly. Stacktrace:", e)
             if attempt <= max_retries:
@@ -55,9 +54,8 @@ def auth_update_sudo(the_query):
     authSparqlUpdate.setQuery(the_query)
     if authSparqlUpdate.isSparqlUpdateRequest():
         start = time.time()
-        logger.debug(f"started query at {datetime.datetime.now()}")
         logger.debug("execute query: \n" + the_query)
 
         authSparqlUpdate.query()
 
-        logger.debug(f"query took {time.time() - start} seconds")
+        logger.debug(f"Query took {round((time.time() - start) * 10**3)} ms")

--- a/services/vocab-fetch/void.py
+++ b/services/vocab-fetch/void.py
@@ -1,0 +1,232 @@
+from string import Template
+from helpers import query, update
+from helpers import generate_uuid, logger
+from sudo_query import query_sudo, update_sudo
+from escape_helpers import sparql_escape, sparql_escape_uri, sparql_escape_string
+
+VOID_GRAPH_URI_BASE = "http://example.com/graph/"
+
+# Queries adapted from https://github.com/cygri/make-void by Richard Cygniak
+
+def generate_insert_property_partitions(dataset_contents_g, dataset, graph):
+    property_partition_base = str(dataset) + "_property"
+    query_template = Template("""
+PREFIX void: <http://rdfs.org/ns/void#>
+
+INSERT {
+    GRAPH $void_graph {
+        $dataset
+            void:propertyPartition ?pp .
+        ?pp a void:Dataset;
+            void:property ?p;
+            void:triples ?triples;
+            void:distinctSubjects ?subjects;
+            void:distinctObjects ?objects .
+    }
+}
+WHERE {
+  {
+    SELECT (COUNT(*) AS ?triples) (COUNT(DISTINCT ?s) AS ?subjects) (COUNT(DISTINCT ?o) AS ?objects) ?p
+    WHERE {
+        GRAPH $dataset_contents_graph {
+            ?s ?p ?o .
+        }
+    }
+    GROUP BY ?p
+  }
+  BIND(STRUUID() AS ?uuid)
+  BIND(URI(CONCAT($property_partition_base, ?uuid)) AS ?pp)
+}
+""")
+    query_string = query_template.substitute(
+        dataset_contents_graph=sparql_escape_uri(dataset_contents_g),
+        dataset=sparql_escape_uri(dataset),
+        property_partition_base=sparql_escape_string(property_partition_base),
+        void_graph=sparql_escape_uri(graph)
+    )
+    update_sudo(query_string)
+    return graph, dataset
+
+
+def generate_insert_class_partitions(dataset_contents_g, dataset, graph):
+    class_partition_base = str(dataset) + "_class"
+    query_template = Template("""
+PREFIX void: <http://rdfs.org/ns/void#>
+
+INSERT {
+    GRAPH $void_graph {
+        $dataset
+            void:classPartition ?cp .
+        ?cp a void:Dataset;
+            void:class ?type;
+            void:entities ?instances .
+    }
+}
+WHERE {
+    {
+        SELECT (COUNT(DISTINCT ?instance) AS ?instances) ?type
+        WHERE {
+            GRAPH $dataset_contents_graph {
+                ?instance a ?type .
+                FILTER (isURI(?type))
+            }
+        }
+        GROUP BY ?type
+    }
+    BIND(STRUUID() AS ?uuid)
+    BIND(URI(CONCAT($class_partition_base, ?uuid)) AS ?cp)
+}
+""")
+    query_string = query_template.substitute(
+        dataset_contents_graph=sparql_escape_uri(dataset_contents_g),
+        dataset=sparql_escape_uri(dataset),
+        class_partition_base=sparql_escape_string(class_partition_base),
+        void_graph=sparql_escape_uri(graph)
+    )
+    update_sudo(query_string)
+    return graph, dataset
+
+def generate_insert_summary(dataset_contents_g, dataset, graph):
+    query_template = Template("""
+PREFIX void: <http://rdfs.org/ns/void#>
+
+INSERT {
+    GRAPH $void_graph {
+        $dataset
+            void:triples ?triples;
+            void:entities ?entities;
+            void:classes ?classes;
+            void:properties ?properties.
+    }
+}
+WHERE {
+    {
+        SELECT (COUNT(*) AS ?triples) (COUNT(DISTINCT ?p) AS ?properties)
+        WHERE {
+            GRAPH $dataset_contents_graph {
+                ?s ?p ?o .
+            }
+        }
+    }
+    {
+        SELECT (COUNT(DISTINCT ?type) AS ?classes)
+        WHERE {
+            GRAPH $dataset_contents_graph {
+                [] a ?type .
+                FILTER (isURI(?type))
+            }
+        }
+    }
+    {
+        SELECT (COUNT(DISTINCT ?s) AS ?entities)
+        WHERE {
+            GRAPH $dataset_contents_graph {
+                ?s ?p ?o .
+            }
+        }
+    }
+}
+""")
+    query_string = query_template.substitute(
+        dataset_contents_graph=sparql_escape_uri(dataset_contents_g),
+        dataset=sparql_escape_uri(dataset),
+        void_graph=sparql_escape_uri(graph)
+    )
+    update_sudo(query_string)
+    return graph, dataset
+
+def generateVoID(dataset_contents_g, dataset, graph):
+    generate_insert_class_partitions(dataset_contents_g, dataset, graph)
+    generate_insert_property_partitions(dataset_contents_g, dataset, graph)
+    generate_insert_summary(dataset_contents_g, dataset, graph)
+    return graph, dataset
+
+def generate_delete_class_partitions(dataset, graph):
+    # Note the missing delete of dataset rdf type triple
+    query_template = Template("""
+PREFIX void: <http://rdfs.org/ns/void#>
+
+DELETE {
+    GRAPH $void_graph {
+        $dataset void:classPartition ?cp .
+        ?cp ?cpp ?cpo .
+    }
+}
+WHERE {
+    GRAPH $void_graph {
+        $dataset a void:Dataset;
+            void:classPartition ?cp .
+        ?cp ?cpp ?cpo .
+    }
+}
+""")
+    query_string = query_template.substitute(
+        dataset=sparql_escape_uri(dataset),
+        void_graph=sparql_escape_uri(graph)
+    )
+    update_sudo(query_string)
+    return graph, dataset
+
+def generate_delete_property_partitions(dataset, graph):
+    # Note the missing delete of dataset rdf type triple
+    query_template = Template("""
+PREFIX void: <http://rdfs.org/ns/void#>
+
+DELETE {
+    GRAPH $void_graph {
+        $dataset void:propertyPartition ?pp .
+        ?pp ?ppp ?ppo .
+    }
+}
+WHERE {
+    GRAPH $void_graph {
+        $dataset a void:Dataset;
+            void:propertyPartition ?pp .
+        ?pp ?ppp ?ppo .
+    }
+}
+""")
+    query_string = query_template.substitute(
+        dataset=sparql_escape_uri(dataset),
+        void_graph=sparql_escape_uri(graph)
+    )
+    update_sudo(query_string)
+    return graph, dataset
+
+
+def generate_delete_summary(dataset, graph):
+    # Note the missing delete of dataset rdf type triple
+    query_template = Template("""
+PREFIX void: <http://rdfs.org/ns/void#>
+
+INSERT {
+    GRAPH $void_graph {
+        $dataset
+            void:triples ?triples;
+            void:entities ?entities;
+            void:classes ?classes;
+            void:properties ?properties.
+    }
+}
+WHERE {
+    GRAPH $void_graph {
+        $dataset a void:Dataset;
+            void:triples ?triples;
+            void:entities ?entities;
+            void:classes ?classes;
+            void:properties ?properties.
+    }
+}
+""")
+    query_string = query_template.substitute(
+        dataset=sparql_escape_uri(dataset),
+        void_graph=sparql_escape_uri(graph)
+    )
+    update_sudo(query_string)
+    return graph, dataset
+
+def deleteVoID(dataset, graph):
+    generate_delete_class_partitions(dataset, graph)
+    generate_delete_property_partitions(dataset, graph)
+    generate_delete_summary(dataset, graph)
+    return graph, dataset

--- a/services/vocab-fetch/web.py
+++ b/services/vocab-fetch/web.py
@@ -277,14 +277,11 @@ def update_ldes_dataset_dump():
 
 
 if UPDATE_DATASET_DUMP_CRON_PATTERN:
-    # work around running the cron job twice in flask dev mode
-    # context: https://stackoverflow.com/questions/25504149/why-does-running-the-flask-dev-server-run-itself-twice
-    from werkzeug.serving import is_running_from_reloader
-    if is_running_from_reloader():
-        scheduler = BackgroundScheduler()
-        logger.info(f"Configuring dataset dump update cron interval {UPDATE_DATASET_DUMP_CRON_PATTERN}")
-        scheduler.add_job(update_ldes_dataset_dump, CronTrigger.from_crontab(UPDATE_DATASET_DUMP_CRON_PATTERN))
-        scheduler.start()
+    scheduler = BackgroundScheduler()
+    logger.info(f"Configuring dataset dump update cron interval {UPDATE_DATASET_DUMP_CRON_PATTERN}")
+    scheduler.add_job(update_ldes_dataset_dump, CronTrigger.from_crontab(UPDATE_DATASET_DUMP_CRON_PATTERN))
+    logger.info(f"Starting Cron scheduler")
+    scheduler.start()
 
 @app.route("/delta", methods=["POST"])
 def process_delta():

--- a/services/vocab-fetch/web.py
+++ b/services/vocab-fetch/web.py
@@ -267,6 +267,8 @@ def update_ldes_dataset_dump():
     datasets = query_outdated_dump_ldes_datasets()
     if datasets:
         logger.info("LDES datasets needing dump update: " + str(datasets))
+    else:
+        logger.info("No LDES datasets requiring a dump update found.")
     for dataset in datasets:
         logger.info(f"Creating dump task for dataset {dataset}")
         qs = create_download_task(dataset, TASKS_GRAPH)

--- a/services/vocab-fetch/web.py
+++ b/services/vocab-fetch/web.py
@@ -11,7 +11,7 @@ from helpers import query, update
 from sudo_query import query_sudo, update_sudo
 
 from rdflib import Graph, URIRef, Literal
-from rdflib.void import generateVoID
+from void import generateVoID, deleteVoID
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -182,41 +182,17 @@ def run_dataset_download_route(task_uuid: str):
     return ""
 
 
-def remove_old_metadata_from_graph(g, graph_name):
-    for s, p, _ in g.triples((None, None, None)):
-        if p == URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'):
-            continue
-        deletequery = "\n".join(
-            [f"PREFIX {prefix}: {ns.n3()}" for prefix, ns in g.namespaces()]
-        )
-        deletequery += (
-            f"\nDELETE WHERE {{\n\tGRAPH {sparql_escape_uri(graph_name)} {{\n"
-        )
-        deletequery += f" \t\t{s.n3()} {p.n3()} ?o ."
-        deletequery += f" \n\t }}\n}}\n"
-        update_sudo(deletequery)
-
 
 def generate_dataset_structural_metadata(dataset_uri, should_return_vocab):
     dataset_res = query_sudo(get_dataset(dataset_uri, VOID_DATASET_GRAPH))["results"][
         "bindings"
     ][0]
-    if "data_dump" in dataset_res.keys():
-        dataset_contents_g = load_vocab_file(
-            dataset_res["data_dump"]["value"], FILES_GRAPH
-        )
-    else:
-        dataset_contents_g = load_vocab_graph(dataset_res["dataset_graph"]["value"])
-    dataset_meta_g, dataset = generateVoID(
-        dataset_contents_g, dataset=URIRef(dataset_uri)
-    )
     # We update dataset metadata by purging old and re-loadind new data (instead of applying the diff)
     # This has some unexpected consequences, since ldes consumer-manager triggers on addition and
     # removal of void:Datasets. Since our actual intention isn't to remove the whole object (including type), but
     # rather to update more detailed properties, we exclude the `rdf:type` predicate from the removal process.
-    remove_old_metadata_from_graph(dataset_meta_g, VOID_DATASET_GRAPH)
-    for query_string in serialize_graph_to_sparql(dataset_meta_g, VOID_DATASET_GRAPH):
-        update_sudo(query_string)
+    deleteVoID(dataset_uri, VOID_DATASET_GRAPH)
+    generateVoID(dataset_res["dataset_graph"]["value"], dataset_uri, VOID_DATASET_GRAPH)
     if should_return_vocab:
       return dataset_res["vocab"]["value"]
     else:


### PR DESCRIPTION
Rework of the Vocabserver app backend services, mainly containing:
- Sparql-based VoID analyses (instead of rdflib in-memory)
- Upgrade of mu-authorization (general performance, especially noticeable when ingesting ldes)
- bugfix to uuid-generation service
- bugfix to ldes-consumer-manager, reusing existing ldes target graph when available on new container startup.
- improved debug-logging
- fixed dataset-dump cron triggering and adjusted cron frequency